### PR TITLE
Added BatchedObservationWrapper

### DIFF
--- a/anyrl/envs/wrappers/__init__.py
+++ b/anyrl/envs/wrappers/__init__.py
@@ -2,7 +2,7 @@
 Environments that wrap and modify other environments.
 """
 
-from .batched import BatchedWrapper, BatchedFrameStack
+from .batched import BatchedWrapper, BatchedFrameStack, BatchedObservationWrapper
 from .image import DownsampleEnv, FrameStackEnv, GrayscaleEnv, MaxEnv, ResizeImageEnv
 from .logs import LoggedEnv
 from .meta import RL2Env, SwitchableEnv, JointEnv

--- a/anyrl/envs/wrappers/batched.py
+++ b/anyrl/envs/wrappers/batched.py
@@ -108,12 +108,22 @@ class BatchedObservationWrapper(BatchedWrapper):
     Different from `ObsWrapperBatcher` as this calls observation() once with all
     of the observations from the batched environments, allowing you to perform
     optimized observation updates on all observations at once.
+
+    Be sure to modify self.observation_space in your __init__ function if necessary
     """
 
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def observation(self, obses):
+    def observation(self, batched_obses):
+        """
+        Modifies given batched observations into output batched observations
+
+        Arguments
+            batched_obses: List containing batched observations from child observations.
+        Returns: 
+            List containing modified batched observations
+        """
         pass
 
     def reset_wait(self, **args):

--- a/anyrl/envs/wrappers/batched.py
+++ b/anyrl/envs/wrappers/batched.py
@@ -102,6 +102,10 @@ class BatchedFrameStack(BatchedWrapper):
         return [o.copy() for o in self._history[sub_batch]]
 
 class BatchedObservationWrapper(BatchedWrapper):
+    """
+    The batched analog of ObservationWrapper
+    """
+
     __metaclass__ = ABCMeta
 
     def __init__(self, env, **args):

--- a/anyrl/envs/wrappers/batched.py
+++ b/anyrl/envs/wrappers/batched.py
@@ -105,11 +105,13 @@ class BatchedObservationWrapper(BatchedWrapper):
     """
     The batched analog of ObservationWrapper.
 
-    Different from `ObsWrapperBatcher` as this calls observation() once with all
-    of the observations from the batched environments, allowing you to perform
-    optimized observation updates on all observations at once.
+    Different from `ObsWrapperBatcher` as this calls
+    observation() once with all of the observations from the
+    batched environments, allowing you to perform optimized
+    observation updates on all observations at once.
 
-    Be sure to modify self.observation_space in your __init__ function if necessary
+    Be sure to modify self.observation_space in your
+    __init__ function if necessary
     """
 
     __metaclass__ = ABCMeta
@@ -117,10 +119,12 @@ class BatchedObservationWrapper(BatchedWrapper):
     @abstractmethod
     def observation(self, batched_obses):
         """
-        Modifies given batched observations into output batched observations
+        Modifies given batched observations into output
+        batched observations
 
         Arguments
-            batched_obses: List containing batched observations from child observations.
+            batched_obses: List containing batched
+            observations from child observations.
         Returns: 
             List containing modified batched observations
         """
@@ -138,7 +142,8 @@ class BatchedObservationWrapper(BatchedWrapper):
 
 class ObsWrapperBatcher(BatchedObservationWrapper):
     """
-    Converts a gym.ObservationWrapper into a BatchedObservationWrapper
+    Converts a gym.ObservationWrapper into a
+    BatchedObservationWrapper
 
     This assumes that the ObservationWrapper is stateless.
     """

--- a/anyrl/envs/wrappers/batched.py
+++ b/anyrl/envs/wrappers/batched.py
@@ -126,9 +126,9 @@ class BatchedObservationWrapper(BatchedWrapper):
         obses = self.observation(obses)
         return obses, rews, dones, infos
 
-class ObsWrapperBatcher(BatchedWrapper):
+class ObsWrapperBatcher(BatchedObservationWrapper):
     """
-    A batched version of any gym.ObservationWrapper.
+    Converts a gym.ObservationWrapper into a BatchedObservationWrapper
 
     This assumes that the ObservationWrapper is stateless.
     """
@@ -148,14 +148,8 @@ class ObsWrapperBatcher(BatchedWrapper):
         self.wrapper = wrap_fn(_AttrEnv(env), *args, **kwargs)
         self.observation_space = self.wrapper.observation_space
 
-    def reset_wait(self, sub_batch=0):
-        obses = super(ObsWrapperBatcher, self).reset_wait(sub_batch=sub_batch)
+    def observation(self, obses):
         return map(self.wrapper.observation, obses)
-
-    def step_wait(self, sub_batch=0):
-        obses, rews, dones, infos = super(ObsWrapperBatcher, self).step_wait(sub_batch=sub_batch)
-        return map(self.wrapper.observation, obses), rews, dones, infos
-
 
 class ActWrapperBatcher(BatchedWrapper):
     """


### PR DESCRIPTION
I've added BatchedObservationWrapper which is a small wrapper around BatchedWrapper that makes it easy to perform batched observation modifications.

Example of it in use:

```
class BatchedResizeImageWrapper( BatchedObservationWrapper ):
    def __init__( self, env, size=( 84, 84 ), method=tf.image.ResizeMethod.AREA, **args ):
        config = tf.ConfigProto( device_count={ 'GPU': 0 } )
        self._sess = tf.Session( config=config )
        self._images = tf.placeholder( tf.int32, shape=( None, ) + env.observation_space.shape )
        self._resized = tf.image.resize_images( self._images, size, method=method )

        super( BatchedResizeImageWrapper, self ).__init__( env, **args )

    def observation( self, obses ):
        return self._sess.run( self._resized, { self._images: obses } )
```